### PR TITLE
Store key in home directory config file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,9 @@ deps:
 	$(GOGET) github.com/jstemmer/go-junit-report
 	$(GOGET) github.com/mitchellh/gox
 	$(GOGET) github.com/mitchellh/go-homedir
+	$(GOGET) github.com/nu7hatch/gouuid
 	$(GOGET) github.com/olekukonko/tablewriter
 	$(GOGET) github.com/pkg/errors
+	$(GOGET) github.com/sethvargo/go-diceware/diceware
 	$(GOGET) github.com/spf13/cobra
 	$(GOGET) github.com/spf13/viper

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Available Commands:
   init        Initialize a lockgit vault
   reveal-key  Reveal the lockgit key for the current repo
   unlock      Set the key for the current vault
+  lock        Delete the key for the current vault
   ls          List the files in the lockgit vault
   add         Add files to the vault
   commit      Commit changes of tracked files to the vault
@@ -65,8 +66,10 @@ First, initialize a new vault in the `myserverconfig` directory:
  
 ```
 $ lockgit init
-Initialized empty lockgit vault in /home/myserverconfig/.lockgit
+Initialized empty lockgit vault 'flattered-gusto' in /home/myserverconfig/.lockgit
 ```
+
+If there are no parameters to init, lockgit will make up a name to refer to the repo.  This can be changed later with `rename`.
 
 ##### Add secrets
 Next, add the secrets to it
@@ -86,16 +89,16 @@ something like this:
 ├── data
 │   ├── uJl28qpmje-cWGDUv3p8iiJgcANTPKdK
 │   └── yocrUblPqDoRaKYnjE6VfQLQo6LrlrHT
-├── key
+├── lgconfig
 └── manifest
 ``` 
 
 ##### Use source conntrol
-You should check the `.lockgit` folder into source control, with the exception of the `key` file.  
+You should check the entire `.lockgit` folder into source control.  
 
-Lockgit can also update `.gitignore` as you use it.  We now have three secrets in
-the `myserverconfig` folder: `.lockgit/key`, `config/tls.key`, and `creds/awscred`.
-All of these files have been added to `.gitignore` to help prevent them from being
+Lockgit can also update `.gitignore` as you use it.  We now have two secrets in
+the `myserverconfig` folder: `config/tls.key`, and `creds/awscred`.
+Both of these files have been added to `.gitignore` to help prevent them from being
 checked in.
 
 ##### Delete and Restore plaintext secrets
@@ -108,11 +111,16 @@ $ lockgit reveal-key
 FA633KF422AXETBBMXUZYNXZDXN4VRKSE4TI4N2KTXYHV6MUAHQA
 ```  
 
-To use this key to recreate the `key` file, use `unlock`
+To use this key to unlock the vault, use `unlock`
 
 ```
 $ lockgit unlock FA633KF422AXETBBMXUZYNXZDXN4VRKSE4TI4N2KTXYHV6MUAHQA
 ```
+
+The key is saved to your home directory in the config file `~/.lockgit.yml` (unless you overrode this location from
+the command line).  You can remove the key from the config file by using `lock`.  Be wary that this will delete your key,
+so if it isn't written down somewhere, you will lose the contents of the vault.
+
 
 ##### Make changes to your secrets
 After you update a secret, lockgit can detect the change.

--- a/pkg/cmd/lock.go
+++ b/pkg/cmd/lock.go
@@ -1,0 +1,46 @@
+// Copyright © 2018 Jesse Swidler <jswidler@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cmd
+
+import (
+	"github.com/jswidler/lockgit/pkg/app"
+	"github.com/jswidler/lockgit/pkg/log"
+	"github.com/spf13/cobra"
+)
+
+// lockCmd represents the lock command
+var lockCmd = &cobra.Command{
+	Use:   "lock",
+	Short: "Delete the key for the current vault",
+	Long: `Delete the key for the current vault.
+
+You will not be able to recover the key after running this command.  It requires --force to work.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		err := app.UnsetKey(app.Options{Wd: wd, Force: force})
+		log.FatalExit(err)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(lockCmd)
+
+	addForceFlag(lockCmd, "force is required for this operation to succeed")
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -23,6 +23,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/jswidler/lockgit/pkg/log"
 	"github.com/mitchellh/go-homedir"
@@ -56,27 +57,28 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.lockgit.yaml)")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is ~/.lockgit.yml)")
 	rootCmd.PersistentFlags().BoolVarP(&noUpdateGitignore, "no-update-gitignore", "", false, "disable updating .gitignore file")
 
 	viper.BindPFlag("noUpdateGitignore", rootCmd.PersistentFlags().Lookup("no-update-gitignore"))
 }
 
-// initConfig reads in config file and ENV variables if set.
 func initConfig() {
-	if cfgFile != "" {
-		// Use config file from the flag.
-		viper.SetConfigFile(cfgFile)
+	InitConfig(cfgFile)
+}
+
+// initConfig reads in config file and ENV variables if set.
+func InitConfig(file string) {
+	if file != "" {
+		// Use specified file
+		viper.SetConfigFile(file)
 	} else {
 		// Find home directory.
 		home, err := homedir.Dir()
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
-		// Search config in home directory with name ".lockgit" (without extension).
-		viper.AddConfigPath(home)
-		viper.SetConfigName(".lockgit")
+		log.FatalExit(err)
+
+		// Use the .lockgit.yml config file in the home dir
+		viper.SetConfigFile(filepath.Join(home, ".lockgit.yml"))
 	}
 
 	viper.AutomaticEnv() // read in environment variables that match

--- a/pkg/content/datafile.go
+++ b/pkg/content/datafile.go
@@ -34,7 +34,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/jswidler/lockgit/pkg/context"
 	"github.com/jswidler/lockgit/pkg/log"
 	"github.com/pkg/errors"
 )
@@ -46,7 +45,7 @@ type Datafile struct {
 	Perm int
 }
 
-func NewDatafile(ctx context.Context, path string) (Datafile, error) {
+func NewDatafile(ctx Context, path string) (Datafile, error) {
 	d := Datafile{}
 	absPath, err := filepath.Abs(path)
 	if err != nil {
@@ -81,14 +80,14 @@ func (d Datafile) Serialize() []byte {
 	return jsondata
 }
 
-func (d Datafile) Write(ctx context.Context, filemeta Filemeta) {
+func (d Datafile) Write(ctx Context, filemeta Filemeta) {
 	path := MakeDatafilePath(ctx, filemeta)
 	ciphertext := encrypt(ctx.Key, compress(d.Serialize()))
 	err := ioutil.WriteFile(path, ciphertext, 0644)
 	log.FatalPanic(err)
 }
 
-func MakeDatafilePath(ctx context.Context, filemeta Filemeta) string {
+func MakeDatafilePath(ctx Context, filemeta Filemeta) string {
 	return filepath.Join(ctx.DataPath, base64.RawURLEncoding.EncodeToString(filemeta.Sha))
 }
 
@@ -115,7 +114,7 @@ func (d Datafile) MatchesHash(hash []byte) bool {
 	return bytes.Equal(sha, hash[4:])
 }
 
-func ReadDatafile(ctx context.Context, filemeta Filemeta) (Datafile, error) {
+func ReadDatafile(ctx Context, filemeta Filemeta) (Datafile, error) {
 	data := Datafile{}
 	ciphertext, err := ioutil.ReadFile(MakeDatafilePath(ctx, filemeta))
 	if err != nil {

--- a/pkg/content/errors.go
+++ b/pkg/content/errors.go
@@ -1,0 +1,66 @@
+// Copyright © 2018 Jesse Swidler <jswidler@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package content
+
+import (
+	"fmt"
+)
+
+type KeyLoadError struct {
+	message string
+}
+
+func (err *KeyLoadError) Error() string {
+	return err.message
+}
+
+func IsKeyLoadError(err error) bool {
+	if err != nil {
+		switch err.(type) {
+		case *KeyLoadError:
+			return true
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+type ManifestLoadError struct {
+	path   string
+	reason string
+}
+
+func (err *ManifestLoadError) Error() string {
+	return fmt.Sprintf("error loading manifest at %s: %s", err.path, err.reason)
+}
+
+func IsManifestLoadError(err error) bool {
+	if err != nil {
+		switch err.(type) {
+		case *ManifestLoadError:
+			return true
+		default:
+			return false
+		}
+	}
+	return false
+}

--- a/pkg/content/lgconfig.go
+++ b/pkg/content/lgconfig.go
@@ -1,0 +1,79 @@
+// Copyright © 2018 Jesse Swidler <jswidler@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package content
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"strings"
+
+	"github.com/jswidler/lockgit/pkg/log"
+	"github.com/nu7hatch/gouuid"
+	"github.com/pkg/errors"
+	"github.com/sethvargo/go-diceware/diceware"
+)
+
+type LgConfig struct {
+	Ver  int
+	Id   string
+	Name string
+}
+
+func NewLgConfig() LgConfig {
+	id, err := uuid.NewV4()
+	log.FatalPanic(err)
+	tokens, err := diceware.Generate(2)
+	log.FatalPanic(err)
+	name := strings.Join(tokens, "-")
+	return LgConfig{
+		Ver:  1,
+		Id:   id.String(),
+		Name: name,
+	}
+}
+
+func (config LgConfig) Write(path string) {
+	filedata, err := json.Marshal(config)
+	log.FatalPanic(err)
+	err = ioutil.WriteFile(path, filedata, 0644)
+	log.FatalPanic(err)
+}
+
+func ReadConfig(ctx Context) (LgConfig, error) {
+	config := LgConfig{}
+	filedata, err := ioutil.ReadFile(ctx.ConfigPath)
+	if err != nil {
+		return config, err
+	}
+	err = json.Unmarshal(filedata, &config)
+	if err != nil {
+		return config, err
+	}
+
+	// Validate config expectations
+	if config.Id == "" {
+		return config, errors.New("no vault id found in ldconfig")
+	} else if config.Name == "" {
+		return config, errors.New("no vault name found in ldconfig")
+	}
+
+	return config, nil
+}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -19,6 +19,10 @@ func Info(message string) {
 	fmt.Println(message)
 }
 
+func Infof(format string, a ...interface{}) {
+	fmt.Fprintf(os.Stdout, format+"\n", a...)
+}
+
 // for now just print it
 func Verbose(message string) {
 	fmt.Println(message)

--- a/tests/context_test.go
+++ b/tests/context_test.go
@@ -19,6 +19,7 @@ func TestMultipleLockgits(t *testing.T) {
 	setupVault(t, group2Opts)
 	group2file := createFile(group2Opts, "group2file")
 
+	reloadConfig(baseOpts)
 	err := app.AddToVault(baseOpts, basefile)
 	if err != nil {
 		t.Errorf("expected to add basefile to base vault: %s", err)
@@ -29,6 +30,7 @@ func TestMultipleLockgits(t *testing.T) {
 		t.Error("expected to fail to add group1file to base vault")
 	}
 
+	reloadConfig(group1Opts)
 	err = app.AddToVault(group1Opts, group2file)
 	if err == nil {
 		t.Error("expected to fail to add group2file to group1 vault")
@@ -36,10 +38,10 @@ func TestMultipleLockgits(t *testing.T) {
 }
 
 func TestAddLockgitFile(t *testing.T) {
-	opts := opts("lockgitfiltest")
+	opts := opts("lockgitfiletest")
 	setupVault(t, opts)
 
-	keypath := filepath.Join(opts.Wd, ".lockgit", "key")
+	keypath := filepath.Join(opts.Wd, ".lockgit", "ldconfig")
 
 	err := app.AddToVault(opts, []string{keypath})
 	if err == nil {

--- a/tests/helpers_test.go
+++ b/tests/helpers_test.go
@@ -6,15 +6,28 @@ import (
 	"testing"
 
 	"github.com/jswidler/lockgit/pkg/app"
+	"github.com/jswidler/lockgit/pkg/cmd"
+	"github.com/spf13/viper"
 )
 
-func setupVault(t *testing.T, params app.Options) {
-	cleanDir(params.Wd)
+func setupVault(t *testing.T, opts app.Options) {
+	cleanDir(opts.Wd)
+
+	reloadConfig(opts)
+
 	// Initialize the vault
-	err := app.InitVault(params)
+	err := app.InitVault(opts)
 	if err != nil {
 		t.Fatal("InitVault returned an error", err)
 	}
+
+	// Reload the config to get the key
+	reloadConfig(opts)
+}
+
+func reloadConfig(opts app.Options) {
+	viper.Reset()
+	cmd.InitConfig(filepath.Join(opts.Wd, "config.yml"))
 }
 
 func opts(dir string) app.Options {

--- a/tests/init_test.go
+++ b/tests/init_test.go
@@ -1,8 +1,6 @@
 package tests
 
 import (
-	"bufio"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -17,19 +15,6 @@ func TestInitVaultSuccess(t *testing.T) {
 
 	// Test there is a vault and a key
 	testLockgitAndKeyExists(t, opts.Wd)
-
-	// test the key has been added to gitignore
-	gitignore, _ := os.Open(filepath.Join(opts.Wd, ".gitignore"))
-	reader := bufio.NewReader(gitignore)
-	for {
-		readString, err := reader.ReadString('\n')
-		if readString == ".lockgit/key" {
-			// found it
-			break
-		} else if err != nil {
-			t.Error(".lockgit/key not found in .gitignore")
-		}
-	}
 }
 
 func TestInitVaultFailsIfVaultExists(t *testing.T) {
@@ -71,21 +56,6 @@ func testLockgitAndKeyExists(t *testing.T, testProjectPath string) {
 		t.Error(".lockgit exists but has wrong permissons")
 	}
 
-	// Test there is a keyfile
-	keyPath := filepath.Join(lockgitPath, "key")
-	info, _ = os.Stat(keyPath)
-	if info == nil {
-		t.Error(".lockgit/key not found")
-	} else {
-		if !info.Mode().IsRegular() {
-			t.Error(".lockgit/key exists but is not a regular file")
-		}
-		if info.Mode().Perm() != 0644 {
-			t.Error(".lockgit/key exists but has wrong permissons")
-		}
-		bytes, _ := ioutil.ReadFile(keyPath)
-		if len(bytes) != 32 {
-			t.Error(".lockgit/key is not 32 bytes")
-		}
-	}
+	// TODO: Test there is a key in the config file
+
 }


### PR DESCRIPTION
By default the key will now be stored in the home directory config.
If desired, the config path can be set explicitly from the command-line.

The key is being removed from the .lockgit directory to make it less
likely to get checked into source control.  So while you can put the
config file anywhere, it is strongly recommended not to store your keys
inside the git directory.

If a repo was created from v0.5.x, it will be migrated to the new
format automatically when lockgit is run.  The old keyfile will not be
removed to prevent a horrible accident.