### PR TITLE
Use a more secure hashing mechanism

### DIFF
--- a/pkg/app/entry.go
+++ b/pkg/app/entry.go
@@ -267,7 +267,8 @@ func Commit(opts Options) error {
 			hadError = true
 			continue
 		}
-		if !datafile.MatchesHash(filemeta.Sha) {
+
+		if !datafile.MatchesCurrent(filemeta) {
 			err := addFile(ctx, &manifest, filemeta.AbsPath, opts)
 			if err != nil {
 				log.LogError(err)

--- a/pkg/app/lockgit.go
+++ b/pkg/app/lockgit.go
@@ -40,7 +40,7 @@ func openFromVault(ctx c.Context, filemeta c.Filemeta, params Options) error {
 		datafile, err := c.NewDatafile(ctx, filemeta.AbsPath)
 		if err == nil {
 			// Able to read the file
-			if datafile.MatchesHash(filemeta.Sha) {
+			if datafile.MatchesCurrent(filemeta) {
 				log.Verbose(fmt.Sprintf("skipping %s - file exists and matches hash",
 					ctx.RelPath(filemeta.AbsPath)))
 				return nil
@@ -63,9 +63,9 @@ func openFromVault(ctx c.Context, filemeta c.Filemeta, params Options) error {
 	if err != nil {
 		return err
 	}
-	absPath := filepath.Join(ctx.ProjectPath, datafile.Path)
+	absPath := filepath.Join(ctx.ProjectPath, datafile.Path())
 	_ = os.Mkdir(filepath.Dir(absPath), 0755)
-	err = ioutil.WriteFile(absPath, data, os.FileMode(datafile.Perm))
+	err = ioutil.WriteFile(absPath, data, os.FileMode(datafile.Perm()))
 	if err != nil {
 		return err
 	}
@@ -87,7 +87,7 @@ func deletePlaintextFile(ctx c.Context, filemeta c.Filemeta, params Options) err
 			return err
 		}
 
-		if !datafile.MatchesHash(filemeta.Sha) {
+		if !datafile.MatchesCurrent(filemeta) {
 			return fmt.Errorf("%s has changed.  To delete anyway enable --force\n", ctx.RelPath(filemeta.AbsPath))
 		}
 	}
@@ -118,7 +118,7 @@ func addFile(ctx c.Context, manifest *c.Manifest, absPath string, opts Options) 
 	}
 	filemeta := c.NewFilemeta(absPath, datafile)
 
-	datafile.Write(ctx, filemeta)
+	datafile.Write(filemeta)
 
 	if mindx >= 0 {
 		oldDatafile := c.MakeDatafilePath(ctx, manifest.Files[mindx])

--- a/pkg/app/status.go
+++ b/pkg/app/status.go
@@ -65,7 +65,7 @@ func Status(opts Options) ([]string, [][]string) {
 			}
 			updated = "unavailable"
 		} else {
-			updated = strconv.FormatBool(!datafile.MatchesHash(filemeta.Sha))
+			updated = strconv.FormatBool(!datafile.MatchesCurrent(filemeta))
 		}
 
 		patternMatched = util.Filter(patternMatched, func(path string) bool {
@@ -75,7 +75,7 @@ func Status(opts Options) ([]string, [][]string) {
 		table = append(table, []string{
 			filemeta.RelPath,
 			updated,
-			firstMatchedPattern(datafile.Path, ctx.Config.Patterns),
+			firstMatchedPattern(datafile.Path(), ctx.Config.Patterns),
 			filemeta.ShaString(),
 		})
 	}

--- a/pkg/content/filemeta.go
+++ b/pkg/content/filemeta.go
@@ -35,7 +35,7 @@ type Filemeta struct {
 func NewFilemeta(absPath string, datafile Datafile) Filemeta {
 	return Filemeta{
 		AbsPath: absPath,
-		RelPath: datafile.Path,
+		RelPath: datafile.Path(),
 		Sha:     datafile.Hash(),
 	}
 }
@@ -47,27 +47,3 @@ func (f Filemeta) ShaString() string {
 func (f Filemeta) String() string {
 	return fmt.Sprintf("%s\t%s", f.ShaString(), f.RelPath)
 }
-
-/* if you are worried about hash collisions for some reason...
-func hashFileSecure(path string) ([]byte, error) {
-	h := sha256.New()
-	if err := readIn(path,h); err != nil {
-		return nil, err
-	}
-	hash := h.Sum(nil)
-	return bcrypt.GenerateFromPassword(hash, -1)
-}
-
-func CompareToHashSecure(path string, hash []byte) (bool, error) {
-	h := sha256.New()
-	if err := readIn(path,h); err != nil {
-		return false, err
-	}
-	sha := h.Sum(nil)
-	err := bcrypt.CompareHashAndPassword(hash, sha)
-	if err == bcrypt.ErrMismatchedHashAndPassword {
-		return false, nil
-	}
-	return err == nil, err
-}
-*/

--- a/tests/globs_test.go
+++ b/tests/globs_test.go
@@ -93,6 +93,35 @@ func TestDoNotAddGlobWithoutMatches(t *testing.T) {
 	}
 }
 
+func TestCommitNewViaGlob(t *testing.T) {
+	opts := opts("globtest4")
+	setupVault(t, opts)
+	createFilesC(opts.Wd)
+
+	_ = app.AddToVault(opts, []string{"dir1/dir12/**"})
+
+	files := app.Ls(opts)
+	if len(files) != 2 {
+		t.Errorf("expected two files")
+	}
+
+	dir := filepath.Join(opts.Wd, "dir1", "dir12")
+	f1 := filepath.Join(dir, "filea12")
+	f2 := filepath.Join(dir, "new")
+	_ = ioutil.WriteFile(f1, []byte(data2), 0644)
+	_ = ioutil.WriteFile(f2, []byte(data2), 0644)
+
+	err := app.Commit(opts)
+	if err != nil {
+		t.Errorf("commit to succeed")
+	}
+
+	files = app.Ls(opts)
+	if len(files) != 3 {
+		t.Errorf("expected three files")
+	}
+}
+
 func createFilesC(projectdir string) {
 	d1 := filepath.Join(projectdir, "dir1")
 	d2 := filepath.Join(projectdir, "dir2")


### PR DESCRIPTION
Changes the way files are compared to the vault contents, so a vault key is required to compare a file to the vault.

This fixes a security issue due to the fact the hashes of the file are public.

The hashes are salted which prevents the use of precomputed rainbow tables, but if you checked in a simple password that will not stand up to a dictionary attack, an attacker could brute force possibilities against the hash.

Initially, I thought it would be neat to check if a file had changed without having the key loaded into the app, so a salted hash seemed reasonable; but this was also thinking that your secrets will not fall to dictionary attacks. That no longer seems like a good assumption, nor does there seem to be reason to not load the key if you have it.

This change does not cause any previously computed hashes to be recomputed, which would be stored in git history anyway. If your keys will lose to a dictionary attack, you would be encouraged to change them and update LockGit. The new secrets will have hashes that cannot be compared without the key.